### PR TITLE
Add Docker support with configuration instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+# Install the package directly from PyPI
+RUN pip install --no-cache-dir mcp-think-tool
+
+# Find where the executable is installed
+RUN which mcp-think-tool
+
+# Set the MCP think tool as the entrypoint
+ENTRYPOINT ["mcp-think-tool"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install mcp-think-tool
 
 ## Configuration
 
+### Windsurf
 To use this tool with Claude in Windsurf, add the following configuration to your MCP config file:
 
 ```json
@@ -37,3 +38,24 @@ To use this tool with Claude in Windsurf, add the following configuration to you
 ```
 
 The `command` field should point to the directory where you installed the python package using pip.
+
+### Docker
+
+You can install this MCP server with only the Dockerfile
+
+First download the Dockerfile, navigate to its directory, and build the Docker image
+
+````
+docker build -t mcp-think-tool .
+````
+
+Then add the following configuration your MCP config file
+
+````json
+"think": {
+    "command": "docker",
+    "args": ["run", "--rm", "-i", "mcp-think-tool"]
+}
+````
+
+This was tested and working with **Claude Desktop** and **Cursor**


### PR DESCRIPTION
Add Docker support for easier deployment

This PR adds Docker containerization support to the MCP Think Tool server:

- Added Dockerfile for containerized deployment using python:3.11-slim as base image
- Updated README.md with Docker installation and configuration instructions
- Added Docker-specific configuration example for MCP config file

This change makes it easier for users to deploy the tool in containerized environments, reducing setup complexity and ensuring consistent runtime environments.